### PR TITLE
Add listener_http_header_conditions to the resources where it is missing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -189,6 +189,20 @@ resource "aws_lb_listener_rule" "unauthenticated_hosts" {
       values = var.unauthenticated_hosts
     }
   }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
+    }
+  }
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
@@ -224,6 +238,20 @@ resource "aws_lb_listener_rule" "authenticated_hosts_oidc" {
       values = var.authenticated_hosts
     }
   }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
+    }
+  }
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
@@ -254,6 +282,20 @@ resource "aws_lb_listener_rule" "authenticated_hosts_cognito" {
   condition {
     host_header {
       values = var.authenticated_hosts
+    }
+  }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
     }
   }
 }
@@ -335,6 +377,20 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_oidc" {
       values = var.authenticated_paths
     }
   }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
+    }
+  }
 }
 
 resource "aws_lb_listener_rule" "authenticated_hosts_paths_cognito" {
@@ -371,6 +427,20 @@ resource "aws_lb_listener_rule" "authenticated_hosts_paths_cognito" {
   condition {
     path_pattern {
       values = var.authenticated_paths
+    }
+  }
+
+  dynamic "condition" {
+    for_each = length(var.listener_http_header_conditions) > 0 ? [""] : []
+    content {
+      dynamic "http_header" {
+        for_each = var.listener_http_header_conditions
+
+        content {
+          http_header_name = http_header.value["name"]
+          values           = http_header.value["value"]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## what
* Add listener_http_header_conditions to the resources where it is missing

## why
* Add dynamic support for HTTP Header Blocks (RFC7240)

## references
* https://berlingskemedia.atlassian.net/browse/DATA-1429
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule#http_header
